### PR TITLE
Release v1.0.7

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.release/
+CONTRIBUTORS.md

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,16 @@
+# CHANGELOG
+
 ### Unreleased
+
+### [1.0.7] - 2026-05-29
+
+- security: load dygraph from HTTPS CDN
+- fix: hot-reload `graph.ini`
+- doc: README drops nonexistent `http_addr`/`http_port` settings
+- doc: strip stray backticks from `ignore_re` in sample `graph.ini`
+- misc packaging / meta update (#31)
+- test: refactored against test-fixtures 1.7.0 (#30)
+- Bump sqlite3 from 5.1.7 to 6.0.1 (#28)
 
 ### [1.0.6] - 2026-02-07
 
@@ -33,3 +45,4 @@
 [1.0.4]: https://github.com/haraka/haraka-plugin-graph/releases/tag/1.0.4
 [1.0.5]: https://github.com/haraka/haraka-plugin-graph/releases/tag/1.0.5
 [1.0.6]: https://github.com/haraka/haraka-plugin-graph/releases/tag/1.0.6
+[1.0.7]: https://github.com/haraka/haraka-plugin-graph/releases/tag/1.0.7

--- a/README.md
+++ b/README.md
@@ -27,18 +27,14 @@ config settings are stored in config/graph.ini
 
   The file name (or :memory:), where data is stored
 
-- http_addr
-
-  The IP address to listen on for http. Default: `127.0.0.1`.
-
-- http_port
-
-  The port to listen on for http. Default: `8080`.
-
 - ignore_re
 
   Regular expression to match plugins to ignore for logging.
   Default: `queue|graph|relay`
+
+The plugin hangs its routes off Haraka's built-in HTTP server (see Haraka's
+`http.ini` for `http_addr` / `http_port`); it does not bind a listener of its
+own.
 
 <!-- leave these buried at the bottom of the document -->
 

--- a/config/graph.ini
+++ b/config/graph.ini
@@ -4,5 +4,5 @@
 db_file=graphlog.db
 
 ; Regular expression to match plugins to ignore for logging.
-; Default: `queue|graph|relay`
-ignore_re=`queue|graph|relay`
+; Default: queue|graph|relay
+ignore_re=queue|graph|relay

--- a/index.js
+++ b/index.js
@@ -19,29 +19,36 @@ function createTable() {
   ).exec('CREATE INDEX IF NOT EXISTS graphdata_idx ON graphdata (timestamp)')
 }
 
-exports.register = function () {
+exports.load_graph_ini = function () {
   const plugin = this
-  config = plugin.config.get('graph.ini')
-  let ignore_re =
+  config = plugin.config.get('graph.ini', () => {
+    plugin.load_graph_ini()
+  })
+  const raw =
     config.main.ignore_re ||
     plugin.config.get('grapher.ignore_re') ||
     'queue|graph|relay'
-  ignore_re = new RegExp(ignore_re)
+  const ignore_re = new RegExp(raw)
 
-  plugins = { accepted: 0, disconnect_early: 0 }
-
+  const next_plugins = { accepted: 0, disconnect_early: 0 }
   for (const p of plugin.config.get('plugins', 'list')) {
     if (!p.match(ignore_re)) {
-      plugins[p] = 0
+      next_plugins[p] = 0
     }
   }
+  plugins = next_plugins
+  return plugins
+}
+
+exports.register = function () {
+  this.load_graph_ini()
 
   let sqlite3
   try {
     sqlite3 = require('sqlite3').verbose()
   } catch (e) {
-    plugin.logerror(e)
-    plugin.logerror(
+    this.logerror(e.message)
+    this.logerror(
       "unable to load sqlite3, try\n\n\t'npm install -g sqlite3'\n\n",
     )
     return
@@ -51,10 +58,10 @@ exports.register = function () {
   db = new sqlite3.Database(db_name, createTable)
   insert = db.prepare('INSERT INTO graphdata VALUES (?,?)')
 
-  plugin.register_hook('init_http', 'init_http')
-  plugin.register_hook('disconnect', 'disconnect')
-  plugin.register_hook('deny', 'deny')
-  plugin.register_hook('queue_ok', 'queue_ok')
+  this.register_hook('init_http', 'init_http')
+  this.register_hook('disconnect', 'disconnect')
+  this.register_hook('deny', 'deny')
+  this.register_hook('queue_ok', 'queue_ok')
 }
 
 exports.init_http = function (next, server) {
@@ -98,19 +105,18 @@ exports.deny = function (next, connection, params) {
 }
 
 exports.queue_ok = function (next) {
-  const plugin = this
-  insert.bind([new Date().getTime(), 'accepted'], function (err) {
+  insert.bind([new Date().getTime(), 'accepted'], (err) => {
     if (err) {
-      plugin.logerror(`Insert DENY failed: ${err}`)
+      this.logerror(`Insert accepted failed: ${err}`)
       return next()
     }
-    insert.run(function (err2) {
+    insert.run((err2) => {
       if (err2) {
-        plugin.logerror(`Insert failed: ${err2}`)
+        this.logerror(`Insert failed: ${err2}`)
       }
       try {
         insert.reset()
-      } catch (ignore) {}
+      } catch {}
       next()
     })
   })
@@ -121,8 +127,7 @@ exports.handle_root = function (req, res) {
   res.end(`<html>\
         <head>\
             <title>Haraka Mail Graphs</title>\
-            <script src="http://dygraphs.com/dygraph-combined.js"\
-               type="text/javascript"></script>\
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.2.1/dygraph.min.js" integrity="sha512-j+6RLnV/rO2AvirXbl+yU5JATIllIaxbV7FaSgrMkJLQa231kNXziVpbTe9+np8S6fLYiZt8Ou0JUFT84zuJdw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>\
           </head>\
           <body onload="onLoad();">\
           <script>\

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "plugin",
     "graph"
   ],
-  "version": "1.0.6",
+  "version": "1.0.7",
   "homepage": "https://github.com/haraka/haraka-plugin-graph",
   "repository": {
     "type": "git",
@@ -25,7 +25,8 @@
   },
   "optionalDependencies": {},
   "devDependencies": {
-    "@haraka/eslint-config": "^3.0.0"
+    "@haraka/eslint-config": "^3.0.0",
+    "haraka-test-fixtures": "^1.7.0"
   },
   "licenses": [
     {

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,68 @@
-// const assert = require('assert')
+'use strict'
+
+const assert = require('node:assert/strict')
+const { beforeEach, describe, it } = require('node:test')
+
+const { makePlugin } = require('haraka-test-fixtures')
+
+describe('load_graph_ini', () => {
+  let plugin
+
+  beforeEach(() => {
+    plugin = makePlugin('graph', { register: false })
+  })
+
+  it('filters plugin list with the configured ignore_re', () => {
+    plugin.config.get = (name, type) => {
+      if (name === 'graph.ini') return { main: { ignore_re: 'queue|graph' } }
+      if (name === 'plugins')
+        return ['queue/smtp_forward', 'graph', 'access', 'dkim']
+      return undefined
+    }
+    const registry = plugin.load_graph_ini()
+    assert.ok('access' in registry)
+    assert.ok('dkim' in registry)
+    assert.ok(!('queue/smtp_forward' in registry))
+    assert.ok(!('graph' in registry))
+    // canonical buckets still exist
+    assert.equal(registry.accepted, 0)
+    assert.equal(registry.disconnect_early, 0)
+  })
+
+  it('falls back to grapher.ignore_re when graph.ini does not define one', () => {
+    plugin.config.get = (name) => {
+      if (name === 'graph.ini') return { main: {} }
+      if (name === 'grapher.ignore_re') return 'foo|bar'
+      if (name === 'plugins') return ['foo', 'bar', 'baz']
+      return undefined
+    }
+    const registry = plugin.load_graph_ini()
+    assert.ok('baz' in registry)
+    assert.ok(!('foo' in registry))
+    assert.ok(!('bar' in registry))
+  })
+
+  it('uses the documented default when neither knob is set', () => {
+    plugin.config.get = (name) => {
+      if (name === 'graph.ini') return { main: {} }
+      if (name === 'plugins') return ['queue/smtp_forward', 'access', 'graph']
+      return undefined
+    }
+    const registry = plugin.load_graph_ini()
+    assert.ok('access' in registry)
+    assert.ok(!('queue/smtp_forward' in registry))
+    assert.ok(!('graph' in registry))
+  })
+
+  it('passes a watchCb to config.get for hot-reload (C1)', () => {
+    let captured
+    plugin.config.get = (name, opts) => {
+      if (typeof opts === 'function') captured = opts
+      if (name === 'graph.ini') return { main: { ignore_re: 'queue' } }
+      if (name === 'plugins') return ['queue/smtp_forward', 'access']
+      return undefined
+    }
+    plugin.load_graph_ini()
+    assert.equal(typeof captured, 'function', 'expected reload callback')
+  })
+})


### PR DESCRIPTION
- security: load dygraph from HTTPS CDN
- fix: hot-reload `graph.ini`
- doc: README drops nonexistent `http_addr`/`http_port` settings
- doc: strip stray backticks from `ignore_re` in sample `graph.ini`
- misc packaging / meta update (#31)
- test: refactored against test-fixtures 1.7.0 (#30)
- Bump sqlite3 from 5.1.7 to 6.0.1 (#28)
